### PR TITLE
feat:調整 WebSocket I/O 格式以對齊 Backend

### DIFF
--- a/app/hooks/conversation/useConversation.jsx
+++ b/app/hooks/conversation/useConversation.jsx
@@ -99,7 +99,7 @@ export function useConversation(conversationId) {
     //顯示Thinking...效果，不加入訊息隊列
     showThinking();
 
-    const payload = outboundMessageDecorator(content, "demo", conversationId);
+    const payload = outboundMessageDecorator(content, conversationId);
     wsServiceRef.current.send(payload);
   }
 

--- a/app/service/conversation/InternalService/messageDecorator.jsx
+++ b/app/service/conversation/InternalService/messageDecorator.jsx
@@ -15,13 +15,8 @@ const ROLE_MAPPING = {
 export function inboundMessageDecorator(rawData) {
   try {
     const data = JSON.parse(rawData);
-    const { event_type, text } = data;
+    const { text_content, role } = data;
 
-    // 1) 轉換 role
-    const role = ROLE_MAPPING[event_type] || "llm";
-
-    // 2) 不再拼接字串，而是保留原始的 text_content
-    const text_content = text?.text_content ?? [];
     return { role, text_content };
   } catch (err) {
     console.error("[inboundMessageDecorator] parse error:", err, rawData);
@@ -32,19 +27,14 @@ export function inboundMessageDecorator(rawData) {
 /**
  * 組裝要送出的 WebSocket payload
  * @param {string} content - 使用者輸入的文字
- * @param {string} eventType - 與後端協定，如 "test" 或 "message"
  * @returns {object}
  */
 export function outboundMessageDecorator(
   content,
-  eventType = "test",
   conversation_uid
 ) {
   return {
-    event_type: eventType,
     conversation_uid: conversation_uid,
-    text: {
-      text_content: [{ type: "message", content }],
-    },
+    text_content: [{ type: "message", content }],
   };
 }


### PR DESCRIPTION
## 🚀 目的 / Motivation
調整到與 Backend 相符的 websocket 輸入輸出格式，避免版本不一致導致解析錯誤。

## 📝 主要變更 / What’s Changed
 - 刪除 `event_type`
 - 修改 WS inboundMessageDecorator 輸入格式 `{ text_content, role }`
 - 修改 WS outboundMessageDecorator 輸出格式 `{ conversation_uid, text_content }`

## ✅ 如何測試 / How to Test
1. 啟動前端網頁 `http://localhost:30001/`
2. 登入
3. 開啟新對話、傳送訊息
4. 有成功顯示 LLM 回傳的內容就成功

## 🔎 影響範圍 / Impact Analysis
 - WS 輸入輸出格式

## 📷 螢幕截圖 / Demo (可選)
![image](https://github.com/user-attachments/assets/ec8c7716-4615-42da-91d3-4c316efa5f69)
